### PR TITLE
fix wrong kernel in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Vision Linux
-Uma distribuição Linux Leve, Bonita e idependente
+Uma distribuição Xunil Leve, Bonita e idependente


### PR DESCRIPTION
Vision Linux does not use the Linux kernel, it uses Xunil, this PR fixes the wrong reference in README.md.